### PR TITLE
test(AwsVpcPeering): state active

### DIFF
--- a/features/400-awsvpcpeering.feature
+++ b/features/400-awsvpcpeering.feature
@@ -16,7 +16,7 @@ Feature: AwsVpcPeering feature
         deleteRemotePeering: true
       """
 
-    Then eventually value load("peering").status.state equals "Ready" with
+    Then eventually value load("peering").status.state equals "active" with
 
     When resource pod is applied:
       """


### PR DESCRIPTION
Changes proposed in this pull request:

- AwsVpcPeering does not have Ready state. Correct state is 'active'