### PR TITLE
chore: fixing lint-check version and cleaning up e2e test pods

### DIFF
--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec
         with:
           use-verbose-mode: 'no'
           config-file: '.mlc.config.json'

--- a/internal/k8s.go
+++ b/internal/k8s.go
@@ -172,7 +172,7 @@ func (c *k8sClient) List(ctx context.Context, kind, namespace, labelSelector str
 		params = append(params, "-n", namespace)
 	}
 	if labelSelector != "" {
-		params = append(params, "-l", "'"+labelSelector+"'")
+		params = append(params, "-l", labelSelector)
 	}
 	params = append(params, "-o", "json")
 

--- a/internal/resourceApplied.go
+++ b/internal/resourceApplied.go
@@ -56,6 +56,9 @@ func resourceApplied(ctx context.Context, ref string, txt *godog.DocString) erro
 		return errors.New("zero length kind")
 	}
 
+	// set context label to all resources
+	err = unstructured.SetNestedField(val, map[string]interface{}{"context": "cloud-manager-tests"}, "metadata", "labels")
+
 	if len(ref) > 0 {
 		rd = kfrCtx.Get(ref)
 		if rd == nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fixing the version of lint check
- Making sure pods created during e2e tests are deleted at the clean up before execution. This will solve the case that sometimes pods are left behind because features/tests were canceled in the middle before cleaning up the pods themselves. If pods are left, they will block the clean up of pvc, pv and volumes. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
